### PR TITLE
adds mpg_hwy, mpg_city, mpg_mixed, and fuel_cap_g to get_trims

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in carquery.gemspec
 gemspec
 
-group :development, :test do
-  gem 'pry-debugger'
-end
+#group :development, :test do
+#  gem 'pry-debugger'
+#end

--- a/carquery.gemspec
+++ b/carquery.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "vcr"
+  spec.add_development_dependency "rspec-its"
 end

--- a/lib/carquery/resources/trim.rb
+++ b/lib/carquery/resources/trim.rb
@@ -5,7 +5,8 @@ module Carquery
                         :engine_bore_mm, :engine_stroke_mm, :engine_compression, :engine_fuel,
                         :top_speed_kph, :speedup_0_to_100_kph, :drive, :transmission_type,
                         :seats, :doors, :weight_kg, :length_mm, :width_mm, :height_mm,
-                        :wheelbase_mm, :lkm_hwy, :lkm_mixed, :lkm_city, :fuel_cap_l, :sold_in_us,
+                        :wheelbase_mm, :lkm_hwy, :lkm_mixed, :lkm_city, :fuel_cap_l,
+                        :mpg_city, :mpg_hwy, :mpg_mixed, :fuel_cap_g, :sold_in_us,
                         :co2, :make_title, :make_country do
 
     def self.build raw
@@ -43,6 +44,10 @@ module Carquery
       lkm_mixed =             get_f   raw["model_lkm_mixed"]
       lkm_city =              get_f   raw["model_lkm_city"]
       fuel_cap_l =            get_i   raw["model_fuel_cap_l"]
+      mpg_hwy =               get_f   raw["model_mpg_hwy"]
+      mpg_city =              get_f   raw["model_mpg_city"]
+      mpg_mixed =             get_f   raw["model_mpg_mixed"]
+      fuel_cap_g =            get_f   raw["model_fuel_cap_g"]
       sold_in_us =            get_boolean raw["model_sold_in_us"]
       co2 =                   get_i   raw["model_co2"]
       make_title =            get_str raw["make_display"]
@@ -54,9 +59,8 @@ module Carquery
           engine_stroke_mm, engine_compression, engine_fuel, top_speed_kph,
           speedup_0_to_100_kph, drive, transmission_type, seats, doors, weight_kg,
           length_mm, width_mm, height_mm, wheelbase_mm, lkm_hwy, lkm_mixed, lkm_city,
-          fuel_cap_l, sold_in_us, co2, make_title, make_country
+          fuel_cap_l, mpg_city, mpg_hwy, mpg_mixed, fuel_cap_g, sold_in_us, co2,
+          make_title, make_country
     end
   end
 end
-
-

--- a/spec/resources/car_model_spec.rb
+++ b/spec/resources/car_model_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'rspec/its'
 
 describe Carquery::CarModel do
   describe '.build' do

--- a/spec/resources/make_spec.rb
+++ b/spec/resources/make_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'rspec/its'
 
 describe Carquery::Make do
   describe '.build' do

--- a/spec/resources/trim_spec.rb
+++ b/spec/resources/trim_spec.rb
@@ -1,11 +1,12 @@
 require 'spec_helper'
+require 'rspec/its'
 
 describe Carquery::Trim do
   describe '.build' do
     subject { described_class.build data }
 
     context "when valid data provided" do
-      let(:data) { {"model_id"=>"57610", "model_make_id"=>"acura", "model_name"=>"ILX", "model_trim"=>" Hybrid", "model_year"=>"2013", "model_body"=>"Sedan", "model_engine_position"=>"Front", "model_engine_cc"=>"1500", "model_engine_cyl"=>"4", "model_engine_type"=>"in-line", "model_engine_valves_per_cyl"=>"8", "model_engine_power_ps"=>"111", "model_engine_power_rpm"=>"5500", "model_engine_torque_nm"=>"172", "model_engine_torque_rpm"=>"3500", "model_engine_bore_mm"=>"73.0", "model_engine_stroke_mm"=>"89.0", "model_engine_compression"=>"10.8", "model_engine_fuel"=>"Gasoline", "model_top_speed_kph"=>nil, "model_0_to_100_kph"=>nil, "model_drive"=>"Front", "model_transmission_type"=>"CVT ", "model_seats"=>"5", "model_doors"=>"4", "model_weight_kg"=>"1356", "model_length_mm"=>"4550", "model_width_mm"=>"1794", "model_height_mm"=>"1412", "model_wheelbase_mm"=>"2670", "model_lkm_hwy"=>"4.8", "model_lkm_mixed"=>nil, "model_lkm_city"=>"5.0", "model_fuel_cap_l"=>"50", "model_sold_in_us"=>"1", "model_co2"=>nil, "model_make_display"=>nil, "make_display"=>"Acura", "make_country"=>"USA"} }
+      let(:data) { {"model_id"=>"57610", "model_make_id"=>"acura", "model_name"=>"ILX", "model_trim"=>" Hybrid", "model_year"=>"2013", "model_body"=>"Sedan", "model_engine_position"=>"Front", "model_engine_cc"=>"1500", "model_engine_cyl"=>"4", "model_engine_type"=>"in-line", "model_engine_valves_per_cyl"=>"8", "model_engine_power_ps"=>"111", "model_engine_power_rpm"=>"5500", "model_engine_torque_nm"=>"172", "model_engine_torque_rpm"=>"3500", "model_engine_bore_mm"=>"73.0", "model_engine_stroke_mm"=>"89.0", "model_engine_compression"=>"10.8", "model_engine_fuel"=>"Gasoline", "model_top_speed_kph"=>nil, "model_0_to_100_kph"=>nil, "model_drive"=>"Front", "model_transmission_type"=>"CVT ", "model_seats"=>"5", "model_doors"=>"4", "model_weight_kg"=>"1356", "model_length_mm"=>"4550", "model_width_mm"=>"1794", "model_height_mm"=>"1412", "model_wheelbase_mm"=>"2670", "model_lkm_hwy"=>"4.8", "model_lkm_mixed"=>nil,  "model_fuel_cap_g"=>"13.2", "model_lkm_city"=>"5.0", "model_fuel_cap_l"=>"50", "model_mpg_hwy"=>"49", "model_mpg_city"=>"47", "model_mpg_mixed"=>nil, "model_sold_in_us"=>"1", "model_co2"=>nil, "model_make_display"=>nil, "make_display"=>"Acura", "make_country"=>"USA"} }
 
       it { should be_a described_class }
 
@@ -43,6 +44,10 @@ describe Carquery::Trim do
       its(:lkm_mixed)            { should be_nil }
       its(:lkm_city)             { should eq 5.0 }
       its(:fuel_cap_l)           { should eq 50 }
+      its(:fuel_cap_g)           { should eq 13.2 }
+      its(:mpg_city)             { should eq 47 }
+      its(:mpg_hwy)              { should eq 49}
+      its(:mpg_mixed)            { should be_nil }
       its(:sold_in_us)           { should eq true }
       its(:co2)                  { should be_nil }
       its(:make_title)           { should eq "Acura" }


### PR DESCRIPTION
The documentation [here](http://www.carqueryapi.com/documentation/api-usage/) says that all the model fields will be available with GetTrims. The API seems be not working that way. I needed the mpg and fuel tank size in gallons, and it's actually only there if you look up that specific model with GetModel.

I noticed this gem was missing it all together. Now when using `Carquery.get_trim trim_id`, the fields mpg_city, mpg_hwy, mpg_mixed, and fuel_cap_g are included. I included tests, and had to add a gem to get those to run.
